### PR TITLE
Implement generic email API and launch email endpoint

### DIFF
--- a/pages/api/resendCorrectEditLinks.js
+++ b/pages/api/resendCorrectEditLinks.js
@@ -50,13 +50,9 @@ export default async function handler(req, res) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          firstName,
-          email: poll.organiserEmail,
-          pollId: pollDoc.id,
-          editToken: poll.editToken,
-          eventTitle: poll.eventTitle,
-          htmlContent,
+          to: poll.organiserEmail,
           subject,
+          htmlContent,
           sender: { name: 'Gavin at Set The Date', email: 'hello@setthedate.app' },
           replyTo: { name: 'Gavin', email: 'hello@setthedate.app' }
         }),

--- a/pages/api/sendOrganiserEmail.js
+++ b/pages/api/sendOrganiserEmail.js
@@ -1,5 +1,4 @@
 // pages/api/sendOrganiserEmail.js
-import { db } from '@/lib/firebase';
 import { defaultSender, defaultReplyTo } from '@/lib/emailConfig';
 
 export default async function handler(req, res) {
@@ -7,131 +6,37 @@ export default async function handler(req, res) {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }
 
-  const { firstName, email, pollId, editToken, eventTitle } = req.body;
+  const { to, subject, htmlContent, sender, replyTo } = req.body;
 
-  if (!firstName || !email || !pollId || !editToken || !eventTitle) {
+  if (!to || !subject || !htmlContent) {
     return res.status(400).json({ message: 'Missing required fields' });
   }
 
-  const pollLink = `https://plan.setthedate.app/poll/${pollId}`;
-  const editLink = `https://plan.setthedate.app/edit/${pollId}?token=${editToken}`;
-
   try {
-    // Add to Brevo 'Organisers' list
-    await fetch('https://api.brevo.com/v3/contacts', {
+    const response = await fetch('https://api.brevo.com/v3/smtp/email', {
       method: 'POST',
       headers: {
         'api-key': process.env.BREVO_API_KEY,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        email,
-        attributes: { FIRSTNAME: firstName },
-        listIds: [4],
-        updateEnabled: true,
+        sender: sender || defaultSender,
+        replyTo: replyTo || defaultReplyTo,
+        to: [{ email: to }],
+        subject,
+        htmlContent,
       }),
     });
 
-    // --- Share Link Email ---
-    const shareHtml = `
-      <div style="text-align: center;">
-        <img src="https://plan.setthedate.app/images/setthedate-logo.png" width="200" style="border-radius: 16px;" alt="Set The Date logo" />
-      </div>
-      <p>Hey ${firstName},</p>
-      <p>Your <strong>Set The Date</strong> poll is live!</p>
-      <p>Share this link with your friends to collect their votes:</p>
-      <p><a href="${pollLink}" style="font-size: 18px; color: #007bff;">${pollLink}</a></p>
-      <h3 style="margin-top:24px;">📣 Share Event with Friends</h3>
-      <ul style="list-style:none;padding-left:0;font-size:16px;">
-        <li>📲 <a href="https://api.whatsapp.com/send?text=Help%20choose%20a%20date%20for%20'${eventTitle}'%20here:%20${pollLink}">Share via WhatsApp</a></li>
-        <li>📱 <a href="sms:?body=Help%20choose%20a%20date%20for%20'${eventTitle}':%20${pollLink}">Share via SMS</a></li>
-        <li>💬 <a href="https://discord.com/channels/@me">Share via Discord</a></li>
-        <li>📨 <a href="https://slack.com/">Share via Slack</a></li>
-        <li>🔗 <a href="${pollLink}">Copy Poll Link</a></li>
-        <li>📧 <a href="mailto:?subject=Vote%20on%20Dates&body=Hey!%20Help%20choose%20a%20date%20for%20'${eventTitle}'%20here:%20${pollLink}">Share via Email</a></li>
-      </ul>
-      <p style="margin-top:24px;">
-        We’ll notify you as soon as people start responding.<br>
-        <strong>If you have any questions or feedback, just reply to this email – I read every message!</strong>
-      </p>
-      <p>– Gavin<br>Founder, Set The Date</p>
-    `;
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error('❌ Brevo responded with error:', errorText);
+      return res.status(500).json({ message: 'Brevo send failed', error: errorText });
+    }
 
-    const shareText = `
-Hey ${firstName},
-
-Your Set The Date poll is live!
-
-Share this link with your friends to collect their votes:
-${pollLink}
-
-We’ll notify you as soon as people start responding.
-
-If you have any questions or feedback, just reply to this email – I read every message!
-
-– Gavin
-Founder, Set The Date
-    `;
-
-    await fetch('https://api.brevo.com/v3/smtp/email', {
-      method: 'POST',
-      headers: {
-        'api-key': process.env.BREVO_API_KEY,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        sender: defaultSender,
-        replyTo: defaultReplyTo,
-        to: [{ email, name: firstName }],
-        subject: `Your "${eventTitle}" Set The Date poll is live!`,
-        htmlContent: shareHtml,
-        textContent: shareText,
-      }),
-    });
-
-    // --- Edit Link Email ---
-    const editHtml = `
-      <div style="text-align: center;">
-        <img src="https://plan.setthedate.app/images/setthedate-logo.png" width="200" style="border-radius: 16px;" alt="Set The Date logo" />
-      </div>
-      <p>Hey ${firstName},</p>
-      <p>You can manage your <strong>Set The Date</strong> event here:</p>
-      <p><a href="${editLink}" style="font-size: 18px; color: #007bff;">Edit Your Event</a></p>
-      <p><em>This link is private – keep it safe so only you can make changes.</em></p>
-      <p>– Gavin<br>Founder, Set The Date</p>
-    `;
-
-    const editText = `
-Hey ${firstName},
-
-You can manage your Set The Date event here:
-${editLink}
-
-This link is private – keep it safe so only you can make changes.
-
-– Gavin
-Founder, Set The Date
-    `;
-
-    await fetch('https://api.brevo.com/v3/smtp/email', {
-      method: 'POST',
-      headers: {
-        'api-key': process.env.BREVO_API_KEY,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        sender: defaultSender,
-        replyTo: defaultReplyTo,
-        to: [{ email, name: firstName }],
-        subject: `Edit your "${eventTitle}" Set The Date poll – link inside`,
-        htmlContent: editHtml,
-        textContent: editText,
-      }),
-    });
-
-    res.status(200).json({ message: 'Both emails sent successfully.' });
+    res.status(200).json({ message: 'Organiser email sent' });
   } catch (error) {
-    console.error('Error sending organiser emails:', error);
+    console.error('Error sending organiser email:', error);
     res.status(500).json({ message: 'Internal server error' });
   }
 }

--- a/pages/api/sendOrganiserLaunchEmails.js
+++ b/pages/api/sendOrganiserLaunchEmails.js
@@ -1,0 +1,136 @@
+// pages/api/sendOrganiserLaunchEmails.js
+import { defaultSender, defaultReplyTo } from '@/lib/emailConfig';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method Not Allowed' });
+  }
+
+  const { firstName, email, pollId, editToken, eventTitle } = req.body;
+
+  if (!firstName || !email || !pollId || !editToken || !eventTitle) {
+    return res.status(400).json({ message: 'Missing required fields' });
+  }
+
+  const pollLink = `https://plan.setthedate.app/poll/${pollId}`;
+  const editLink = `https://plan.setthedate.app/edit/${pollId}?token=${editToken}`;
+
+  try {
+    // Add to Brevo 'Organisers' list
+    await fetch('https://api.brevo.com/v3/contacts', {
+      method: 'POST',
+      headers: {
+        'api-key': process.env.BREVO_API_KEY,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        email,
+        attributes: { FIRSTNAME: firstName },
+        listIds: [4],
+        updateEnabled: true,
+      }),
+    });
+
+    // --- Share Link Email ---
+    const shareHtml = `
+      <div style="text-align: center;">
+        <img src="https://plan.setthedate.app/images/setthedate-logo.png" width="200" style="border-radius: 16px;" alt="Set The Date logo" />
+      </div>
+      <p>Hey ${firstName},</p>
+      <p>Your <strong>Set The Date</strong> poll is live!</p>
+      <p>Share this link with your friends to collect their votes:</p>
+      <p><a href="${pollLink}" style="font-size: 18px; color: #007bff;">${pollLink}</a></p>
+      <h3 style="margin-top:24px;">📣 Share Event with Friends</h3>
+      <ul style="list-style:none;padding-left:0;font-size:16px;">
+        <li>📲 <a href="https://api.whatsapp.com/send?text=Help%20choose%20a%20date%20for%20'${eventTitle}'%20here:%20${pollLink}">Share via WhatsApp</a></li>
+        <li>📱 <a href="sms:?body=Help%20choose%20a%20date%20for%20'${eventTitle}':%20${pollLink}">Share via SMS</a></li>
+        <li>💬 <a href="https://discord.com/channels/@me">Share via Discord</a></li>
+        <li>📨 <a href="https://slack.com/">Share via Slack</a></li>
+        <li>🔗 <a href="${pollLink}">Copy Poll Link</a></li>
+        <li>📧 <a href="mailto:?subject=Vote%20on%20Dates&body=Hey!%20Help%20choose%20a%20date%20for%20'${eventTitle}'%20here:%20${pollLink}">Share via Email</a></li>
+      </ul>
+      <p style="margin-top:24px;">
+        We’ll notify you as soon as people start responding.<br>
+        <strong>If you have any questions or feedback, just reply to this email – I read every message!</strong>
+      </p>
+      <p>– Gavin<br>Founder, Set The Date</p>
+    `;
+
+    const shareText = `
+Hey ${firstName},
+
+Your Set The Date poll is live!
+
+Share this link with your friends to collect their votes:
+${pollLink}
+
+We’ll notify you as soon as people start responding.
+
+If you have any questions or feedback, just reply to this email – I read every message!
+
+– Gavin
+Founder, Set The Date
+    `;
+
+    await fetch('https://api.brevo.com/v3/smtp/email', {
+      method: 'POST',
+      headers: {
+        'api-key': process.env.BREVO_API_KEY,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        sender: defaultSender,
+        replyTo: defaultReplyTo,
+        to: [{ email, name: firstName }],
+        subject: `Your "${eventTitle}" Set The Date poll is live!`,
+        htmlContent: shareHtml,
+        textContent: shareText,
+      }),
+    });
+
+    // --- Edit Link Email ---
+    const editHtml = `
+      <div style="text-align: center;">
+        <img src="https://plan.setthedate.app/images/setthedate-logo.png" width="200" style="border-radius: 16px;" alt="Set The Date logo" />
+      </div>
+      <p>Hey ${firstName},</p>
+      <p>You can manage your <strong>Set The Date</strong> event here:</p>
+      <p><a href="${editLink}" style="font-size: 18px; color: #007bff;">Edit Your Event</a></p>
+      <p><em>This link is private – keep it safe so only you can make changes.</em></p>
+      <p>– Gavin<br>Founder, Set The Date</p>
+    `;
+
+    const editText = `
+Hey ${firstName},
+
+You can manage your Set The Date event here:
+${editLink}
+
+This link is private – keep it safe so only you can make changes.
+
+– Gavin
+Founder, Set The Date
+    `;
+
+    await fetch('https://api.brevo.com/v3/smtp/email', {
+      method: 'POST',
+      headers: {
+        'api-key': process.env.BREVO_API_KEY,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        sender: defaultSender,
+        replyTo: defaultReplyTo,
+        to: [{ email, name: firstName }],
+        subject: `Edit your "${eventTitle}" Set The Date poll – link inside`,
+        htmlContent: editHtml,
+        textContent: editText,
+      }),
+    });
+
+    res.status(200).json({ message: 'Both emails sent successfully.' });
+  } catch (error) {
+    console.error('Error sending organiser emails:', error);
+    res.status(500).json({ message: 'Internal server error' });
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -100,7 +100,7 @@ export default function Home() {
           entrySource,
         });
 
-        fetch("/api/sendOrganiserEmail", {
+        fetch("/api/sendOrganiserLaunchEmails", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({


### PR DESCRIPTION
## Summary
- add `sendOrganiserLaunchEmails` endpoint for poll creation emails
- refactor `sendOrganiserEmail` to send any organiser email
- update resend edit link script for new API
- call launch email API when a poll is created

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f19080e0083288b3fdfcdc1cdd681