### PR TITLE
Add Firestore event-response export and marketing analytics scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,26 @@ Alternatively, install the Vercel CLI (`npm i -g vercel`) and run `vercel --prod
 from the project root to force a deployment without touching Git.
 
 
+
+---
+
+## Event response analytics (marketing)
+
+To produce marketing-focused stats by `eventType` (e.g. most-responded event type, average respondents, yes/maybe/no mix):
+
+1. Export polls and vote documents from Firestore:
+
+```bash
+node scripts/export-polls-with-votes.js --out tmp/polls-with-votes.json
+```
+
+2. Analyze the export:
+
+```bash
+node scripts/analyze-event-responses.js --input tmp/polls-with-votes.json
+```
+
+The analyzer returns JSON with:
+- `eventTypeStats` sorted by average respondents per poll.
+- Vote mix (`yesRate`, `maybeRate`, `noRate`) per event type.
+- `highlights` including top event type for response volume and yes-rate.

--- a/scripts/analyze-event-responses.js
+++ b/scripts/analyze-event-responses.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+/**
+ * Analyze event response performance from a JSON export.
+ *
+ * Input JSON format:
+ * [
+ *   {
+ *     "id": "pollId",
+ *     "eventType": "meal|general|holiday|...",
+ *     "eventTitle": "...",
+ *     "dates": ["2026-01-01T12:00:00.000Z"],
+ *     "votes": [
+ *       {
+ *         "name": "Alex",
+ *         "votes": { "2026-01-01T12:00:00.000Z": "yes|maybe|no" }
+ *       }
+ *     ]
+ *   }
+ * ]
+ *
+ * Usage:
+ *   node scripts/analyze-event-responses.js --input tmp/polls-with-votes.json
+ */
+
+const fs = require('fs');
+
+const args = process.argv.slice(2);
+const getArg = (name, fallback = null) => {
+  const idx = args.indexOf(name);
+  if (idx === -1) return fallback;
+  return args[idx + 1] ?? fallback;
+};
+
+const inputPath = getArg('--input');
+if (!inputPath) {
+  console.error('Missing --input path to JSON export.');
+  process.exit(1);
+}
+
+const raw = fs.readFileSync(inputPath, 'utf8');
+const polls = JSON.parse(raw);
+
+const toEventType = (p) => (p.eventType || 'general').toLowerCase();
+
+const dedupeVotes = (votes = []) => {
+  const map = new Map();
+
+  for (const vote of votes) {
+    const key = (vote.email || vote.name || vote.displayName || vote.id || '').toString().trim().toLowerCase();
+    const ts = new Date(vote.updatedAt || vote.createdAt || 0).getTime() || 0;
+    if (!key) {
+      map.set(`anon-${Math.random().toString(36).slice(2)}`, vote);
+      continue;
+    }
+    const prev = map.get(key);
+    const prevTs = prev ? new Date(prev.updatedAt || prev.createdAt || 0).getTime() || 0 : -1;
+    if (!prev || ts >= prevTs) map.set(key, vote);
+  }
+
+  return Array.from(map.values());
+};
+
+const getVoteBreakdown = (votes, dates = []) => {
+  let yes = 0;
+  let maybe = 0;
+  let no = 0;
+  let answeredSlots = 0;
+
+  for (const vote of votes) {
+    const ballot = vote.votes || {};
+    const keys = dates.length ? dates : Object.keys(ballot);
+    for (const key of keys) {
+      const value = ballot[key];
+      if (!value) continue;
+      answeredSlots += 1;
+      if (value === 'yes') yes += 1;
+      else if (value === 'maybe') maybe += 1;
+      else if (value === 'no') no += 1;
+    }
+  }
+
+  const weightedScore = yes * 2 + maybe;
+  const weightedAvg = answeredSlots ? weightedScore / answeredSlots : 0;
+  return { yes, maybe, no, answeredSlots, weightedAvg };
+};
+
+const byType = new Map();
+let totalVotesCast = 0;
+let totalPolls = 0;
+
+for (const poll of polls) {
+  totalPolls += 1;
+  const type = toEventType(poll);
+  const uniqueVotes = dedupeVotes(Array.isArray(poll.votes) ? poll.votes : []);
+  const breakdown = getVoteBreakdown(uniqueVotes, Array.isArray(poll.dates) ? poll.dates : []);
+
+  totalVotesCast += uniqueVotes.length;
+
+  if (!byType.has(type)) {
+    byType.set(type, {
+      eventType: type,
+      polls: 0,
+      respondents: 0,
+      yes: 0,
+      maybe: 0,
+      no: 0,
+      answeredSlots: 0,
+      weightedAvgSum: 0,
+      maxRespondents: 0,
+      pollIds: [],
+    });
+  }
+
+  const agg = byType.get(type);
+  agg.polls += 1;
+  agg.respondents += uniqueVotes.length;
+  agg.yes += breakdown.yes;
+  agg.maybe += breakdown.maybe;
+  agg.no += breakdown.no;
+  agg.answeredSlots += breakdown.answeredSlots;
+  agg.weightedAvgSum += breakdown.weightedAvg;
+  agg.maxRespondents = Math.max(agg.maxRespondents, uniqueVotes.length);
+  agg.pollIds.push({ id: poll.id, title: poll.eventTitle || '', respondents: uniqueVotes.length });
+}
+
+const rows = Array.from(byType.values())
+  .map((row) => {
+    const avgRespondents = row.polls ? row.respondents / row.polls : 0;
+    const yesRate = row.answeredSlots ? row.yes / row.answeredSlots : 0;
+    const maybeRate = row.answeredSlots ? row.maybe / row.answeredSlots : 0;
+    const noRate = row.answeredSlots ? row.no / row.answeredSlots : 0;
+    return {
+      eventType: row.eventType,
+      polls: row.polls,
+      respondents: row.respondents,
+      avgRespondents: Number(avgRespondents.toFixed(2)),
+      yesRate: Number((yesRate * 100).toFixed(1)),
+      maybeRate: Number((maybeRate * 100).toFixed(1)),
+      noRate: Number((noRate * 100).toFixed(1)),
+      avgWeightedSlotScore: Number((row.weightedAvgSum / row.polls).toFixed(3)),
+      maxRespondents: row.maxRespondents,
+      topPoll: row.pollIds.sort((a, b) => b.respondents - a.respondents)[0] || null,
+    };
+  })
+  .sort((a, b) => b.avgRespondents - a.avgRespondents);
+
+const output = {
+  generatedAt: new Date().toISOString(),
+  totalPolls,
+  totalRespondents: totalVotesCast,
+  avgRespondentsPerPoll: totalPolls ? Number((totalVotesCast / totalPolls).toFixed(2)) : 0,
+  eventTypeStats: rows,
+  highlights: {
+    mostRespondedEventType: rows[0] || null,
+    highestYesRateEventType: [...rows].sort((a, b) => b.yesRate - a.yesRate)[0] || null,
+    highestMaybeRateEventType: [...rows].sort((a, b) => b.maybeRate - a.maybeRate)[0] || null,
+  },
+};
+
+console.log(JSON.stringify(output, null, 2));

--- a/scripts/export-polls-with-votes.js
+++ b/scripts/export-polls-with-votes.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+
+/**
+ * Export polls + votes from Firestore into a local JSON file.
+ *
+ * Usage:
+ *   node scripts/export-polls-with-votes.js --out tmp/polls-with-votes.json
+ */
+
+const fs = require('fs');
+const path = require('path');
+const admin = require('firebase-admin');
+
+const args = process.argv.slice(2);
+const getArg = (name, fallback) => {
+  const idx = args.indexOf(name);
+  if (idx === -1) return fallback;
+  return args[idx + 1] ?? fallback;
+};
+
+const outPath = getArg('--out', 'tmp/polls-with-votes.json');
+
+const privateKey = process.env.FIREBASE_PRIVATE_KEY_BASE64
+  ? Buffer.from(process.env.FIREBASE_PRIVATE_KEY_BASE64, 'base64').toString('utf8')
+  : process.env.FIREBASE_PRIVATE_KEY
+    ? process.env.FIREBASE_PRIVATE_KEY.replace(/\\n/g, '\n')
+    : null;
+
+const canUseServiceAccount = Boolean(
+  process.env.FIREBASE_PROJECT_ID && process.env.FIREBASE_CLIENT_EMAIL && privateKey
+);
+
+if (!admin.apps.length) {
+  if (canUseServiceAccount) {
+    admin.initializeApp({
+      credential: admin.credential.cert({
+        projectId: process.env.FIREBASE_PROJECT_ID,
+        clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+        privateKey,
+      }),
+    });
+  } else {
+    admin.initializeApp({
+      projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID || process.env.FIREBASE_PROJECT_ID,
+    });
+  }
+}
+
+const db = admin.firestore();
+
+const normalizeTimestamp = (value) => {
+  if (!value) return null;
+  if (typeof value === 'string') return value;
+  if (value && typeof value.toDate === 'function') return value.toDate().toISOString();
+  return null;
+};
+
+(async () => {
+  const pollsSnap = await db.collection('polls').get();
+  const payload = [];
+
+  for (const pollDoc of pollsSnap.docs) {
+    const poll = pollDoc.data();
+    const votesSnap = await db.collection('polls').doc(pollDoc.id).collection('votes').get();
+    const votes = votesSnap.docs.map((voteDoc) => {
+      const data = voteDoc.data();
+      return {
+        id: voteDoc.id,
+        ...data,
+        createdAt: normalizeTimestamp(data.createdAt),
+        updatedAt: normalizeTimestamp(data.updatedAt),
+      };
+    });
+
+    payload.push({
+      id: pollDoc.id,
+      ...poll,
+      createdAt: normalizeTimestamp(poll.createdAt),
+      updatedAt: normalizeTimestamp(poll.updatedAt),
+      deadline: normalizeTimestamp(poll.deadline),
+      finalDate: normalizeTimestamp(poll.finalDate),
+      votes,
+    });
+  }
+
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, JSON.stringify(payload, null, 2));
+  console.log(`Exported ${payload.length} polls to ${outPath}`);
+})();


### PR DESCRIPTION
### Motivation

- Provide a repeatable way to pull poll + vote data out of Firestore and compute marketing-friendly metrics by `eventType` (which event types get the most responses, vote mix, etc.).
- Enable quick answers to questions like “which event type has the highest participation” and “what’s the yes/maybe/no mix per event type” for marketing copy and campaigns.

### Description

- Add `scripts/export-polls-with-votes.js` to export the `polls` collection and each poll’s nested `votes` into a single JSON file while normalising timestamps.
- Add `scripts/analyze-event-responses.js` which groups polls by `eventType` and computes respondents, average respondents per poll, `yes/maybe/no` rates, a weighted slot score, top poll per type, and highlight metrics.
- Document the two-step workflow in `README.md` and provide the exact commands to run the export and analysis locally.

### Testing

- Ran `node scripts/analyze-event-responses.js --input tmp/sample-polls.json` with a synthetic sample and confirmed the analyzer produced the expected JSON summary (success).
- Attempted `node scripts/analyze-event-responses.js --input tmp/polls-with-votes.json` before export and it failed as expected with a missing-file error (handled by the script).
- Attempted `node scripts/export-polls-with-votes.js --out tmp/polls-with-votes.json` against production Firestore but the environment lacked usable Google credentials/network access so the export failed with authentication/connection errors; this is an environment limitation, not a script failure.
- The README now documents the exact commands: `node scripts/export-polls-with-votes.js --out tmp/polls-with-votes.json` and `node scripts/analyze-event-responses.js --input tmp/polls-with-votes.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995c1f71bf083289b8800a803dc0f67)